### PR TITLE
Add pytest setup for frontend routing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,86 @@
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+BACKEND_PORT = 5001
+FRONTEND_PORT = 8080
+
+def _wait_for_server(url: str, timeout: int = 120):
+    """Wait until a server responds at the given URL."""
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            requests.get(url)
+            return
+        except Exception:
+            time.sleep(0.5)
+    raise RuntimeError(f"Server {url} did not start in time")
+
+
+@pytest.fixture(scope="session")
+def backend_server():
+    env = os.environ.copy()
+    env["SANDPIPER_TESTING"] = "1"
+    env["FLASK_APP"] = "api.application:create_app"
+    cmd = [
+        "pixi",
+        "shell",
+        "-e",
+        "sandpiper",
+        "-c",
+        f"flask run --port {BACKEND_PORT} --host 127.0.0.1",
+    ]
+    proc = subprocess.Popen(
+        cmd,
+        cwd=Path(__file__).resolve().parents[1] / "backend",
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+    )
+    try:
+        _wait_for_server(f"http://127.0.0.1:{BACKEND_PORT}")
+        yield f"http://127.0.0.1:{BACKEND_PORT}"
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+@pytest.fixture(scope="session")
+def frontend_server(backend_server):
+    env = os.environ.copy()
+    # ensure npm does not attempt to open browser
+    env["BROWSER"] = "none"
+    vue_dir = Path(__file__).resolve().parents[1] / "vue"
+    if not (vue_dir / "node_modules").exists():
+        pytest.fail("node_modules missing - run npm install")
+    cmd = [
+        "pixi",
+        "shell",
+        "-e",
+        "sandpiper",
+        "-c",
+        f"npm run serve -- --port {FRONTEND_PORT}",
+    ]
+    proc = subprocess.Popen(
+        cmd,
+        cwd=vue_dir,
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+    )
+    try:
+        _wait_for_server(f"http://127.0.0.1:{FRONTEND_PORT}", timeout=240)
+        yield f"http://127.0.0.1:{FRONTEND_PORT}"
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            proc.kill()

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -1,0 +1,22 @@
+import pytest
+import requests
+
+PAGES = [
+    "/",
+    "/search",
+    "/taxonomy/test",
+    "/run/test",
+    "/project",
+    "/otus/test",
+    "/random_run",
+    "/accession/test",
+    "/about",
+]
+
+
+@pytest.mark.parametrize("path", PAGES)
+@pytest.mark.usefixtures("backend_server")
+def test_frontend_pages(frontend_server, path):
+    url = frontend_server + path
+    response = requests.get(url)
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- start Flask backend in pixi's `sandpiper` env with `SANDPIPER_TESTING=1`
- optionally launch Vue frontend and hit each route
- fail fast when frontend dependencies are missing

## Testing
- `pytest tests/test_pages.py -q` *(fails: KeyboardInterrupt waiting for server to start)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cab7a444832ab6a64b38f3b93bf3