### PR TITLE
Add integration tests for page and link availability

### DIFF
--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -1,0 +1,106 @@
+import os
+import subprocess
+import time
+import requests
+from html.parser import HTMLParser
+
+BACKEND_URL = "http://localhost:5000"
+FRONTEND_URL = "http://localhost:5173"
+
+class LinkParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.links = set()
+
+    def handle_starttag(self, tag, attrs):
+        if tag != "a":
+            return
+        href = None
+        for attr, value in attrs:
+            if attr == "href":
+                href = value
+                break
+        if href:
+            self.links.add(href)
+
+
+def wait_for(url, timeout=60):
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            requests.get(url)
+            return
+        except Exception:
+            time.sleep(1)
+    raise RuntimeError(f"Timeout waiting for {url}")
+
+
+import pytest
+
+@pytest.fixture(scope="session", autouse=True)
+def servers():
+    env = os.environ.copy()
+    env["SANDPIPER_TESTING"] = "1"
+
+    backend_cmd = [
+        "pixi", "run", "-e", "sandpiper", "flask", "--app", "wsgi.py", "run"
+    ]
+    backend = subprocess.Popen(backend_cmd, cwd="backend", env=env)
+
+    frontend_cmd = [
+        "pixi", "run", "-e", "sandpiper", "npm", "run", "dev", "--", "--port", "5173"
+    ]
+    frontend = subprocess.Popen(frontend_cmd, cwd="vue", env=env)
+
+    try:
+        wait_for(f"{BACKEND_URL}/api/sandpiper_stats")
+        wait_for(FRONTEND_URL)
+        yield
+    finally:
+        frontend.terminate()
+        backend.terminate()
+        try:
+            frontend.wait(timeout=10)
+        except Exception:
+            frontend.kill()
+        try:
+            backend.wait(timeout=10)
+        except Exception:
+            backend.kill()
+
+
+def test_pages():
+    session = requests.Session()
+    pages = {
+        "/",
+        "/search",
+        "/taxonomy/Bacteria",
+        "/run/ERR2194039",
+        "/project",
+        "/otus/ERR2194039",
+        "/random_run",
+        "/accession/ERR2194039",
+        "/about",
+    }
+
+    resp = session.get(FRONTEND_URL + "/run/ERR2194039")
+    assert resp.status_code == 200
+    parser = LinkParser()
+    parser.feed(resp.text)
+
+    api_links = set()
+    for href in parser.links:
+        if href.startswith("http://localhost:5000"):
+            api_links.add(href)
+        elif href.startswith("http://localhost:5173"):
+            pages.add(href[len("http://localhost:5173"):])
+        elif href.startswith("/"):
+            pages.add(href)
+
+    for path in pages:
+        r = session.get(FRONTEND_URL + path)
+        assert r.status_code == 200, f"{path} returned {r.status_code}"
+
+    for url in api_links:
+        r = session.get(url)
+        assert r.status_code == 200, f"{url} returned {r.status_code}"

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -1,4 +1,5 @@
 import os
+import signal
 import subprocess
 import time
 import requests
@@ -53,8 +54,11 @@ def servers():
         "run",
         "-p",
         "6000",
+        "--no-reload",
     ]
-    backend = subprocess.Popen(backend_cmd, cwd="backend", env=env)
+    backend = subprocess.Popen(
+        backend_cmd, cwd="backend", env=env, start_new_session=True
+    )
 
     frontend_cmd = [
         "pixi",
@@ -68,23 +72,28 @@ def servers():
         "--port",
         "6173",
     ]
-    frontend = subprocess.Popen(frontend_cmd, cwd="vue", env=env)
+    frontend = subprocess.Popen(
+        frontend_cmd, cwd="vue", env=env, start_new_session=True
+    )
 
     try:
         wait_for(f"{BACKEND_URL}/api/sandpiper_stats")
         wait_for(FRONTEND_URL)
         yield
     finally:
-        frontend.terminate()
-        backend.terminate()
-        try:
-            frontend.wait(timeout=10)
-        except Exception:
-            frontend.kill()
-        try:
-            backend.wait(timeout=10)
-        except Exception:
-            backend.kill()
+        for proc in (frontend, backend):
+            try:
+                os.killpg(proc.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+        for proc in (frontend, backend):
+            try:
+                proc.wait(timeout=10)
+            except Exception:
+                try:
+                    os.killpg(proc.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
 
 
 def test_pages():

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -4,8 +4,8 @@ import time
 import requests
 from html.parser import HTMLParser
 
-BACKEND_URL = "http://localhost:5000"
-FRONTEND_URL = "http://localhost:5173"
+BACKEND_URL = "http://localhost:6000"
+FRONTEND_URL = "http://localhost:6173"
 
 class LinkParser(HTMLParser):
     def __init__(self):
@@ -43,12 +43,30 @@ def servers():
     env["SANDPIPER_TESTING"] = "1"
 
     backend_cmd = [
-        "pixi", "run", "-e", "sandpiper", "flask", "--app", "wsgi.py", "run"
+        "pixi",
+        "run",
+        "-e",
+        "sandpiper",
+        "flask",
+        "--app",
+        "wsgi.py",
+        "run",
+        "-p",
+        "6000",
     ]
     backend = subprocess.Popen(backend_cmd, cwd="backend", env=env)
 
     frontend_cmd = [
-        "pixi", "run", "-e", "sandpiper", "npm", "run", "dev", "--", "--port", "5173"
+        "pixi",
+        "run",
+        "-e",
+        "sandpiper",
+        "npm",
+        "run",
+        "dev",
+        "--",
+        "--port",
+        "6173",
     ]
     frontend = subprocess.Popen(frontend_cmd, cwd="vue", env=env)
 
@@ -90,10 +108,10 @@ def test_pages():
 
     api_links = set()
     for href in parser.links:
-        if href.startswith("http://localhost:5000"):
+        if href.startswith("http://localhost:6000"):
             api_links.add(href)
-        elif href.startswith("http://localhost:5173"):
-            pages.add(href[len("http://localhost:5173"):])
+        elif href.startswith("http://localhost:6173"):
+            pages.add(href[len("http://localhost:6173"):])
         elif href.startswith("/"):
             pages.add(href)
 


### PR DESCRIPTION
## Summary
- start Flask backend and Vue frontend during tests using pixi and SANDPIPER_TESTING
- crawl run page links and ensure every page and internal API responds

## Testing
- `pytest tests -x --capture=no -v`


------
https://chatgpt.com/codex/tasks/task_e_68a51c4da1f0832a96c9cd81c472c2ef