### PR TITLE
Add CI workflow to run tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,26 @@
+name: run tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: install dependencies and run tests
+        env:
+          FOLDER_NAME: sandpiper
+        run: |
+          curl -fsSL https://pixi.sh/install.sh | sh
+          ln -s "$HOME/.pixi/bin/pixi" /usr/local/bin -v
+          eval "$(pixi shell-hook -e sandpiper --frozen --manifest-path $GITHUB_WORKSPACE/pixi.toml)"
+          wget 'https://www.dropbox.com/scl/fi/h3wcioieujurjev0rzoya/sandpiper_19_test.sqlite3.gz?rlkey=fmmcd7ovallkzndborbgg6ta7&st=krobed74&dl=0' -O backend/db/sandpiper_19_test.sqlite3.gz && gunzip backend/db/sandpiper_19_test.sqlite3.gz
+          cd vue && npm install && cd -
+          pytest tests --capture=no -v


### PR DESCRIPTION
## Summary
- add GitHub Action to install pixi, set up dependencies, and run pytest on pushes and PRs

## Testing
- `pytest tests --capture=no -v` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a53f189c9c832a935602407b31c98f