### PR TITLE
Handle search result loading state to prevent null errors

### DIFF
--- a/vue/src/views/SearchResult.vue
+++ b/vue/src/views/SearchResult.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="section">
-    <div v-if="search_result !== null" class="container">
+    <div v-if="search_result !== null && total_num_results !== null" class="container">
       <section class="section">
         <h1 class="title" style="text-align: center;">
           The {{ taxonomy_level }}
@@ -145,7 +145,7 @@
 
       <div v-else>
         <section class="section container">
-          Searching ..
+          Loading...
         </section>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Wait for both global and run data before rendering taxonomy search results
- Show a loading message while taxonomy search results load

## Testing
- `pytest tests --capture=no -v`


------
https://chatgpt.com/codex/tasks/task_e_68a66d8a0228832ab67bb1388d15706b