### PR TITLE
Add CTAS table for condensed profiles to speed taxonomy search

### DIFF
--- a/backend/api/api.py
+++ b/backend/api/api.py
@@ -3,7 +3,6 @@ api.py
 - provides the API endpoints for consuming and producing
   REST requests and responses
 """
-from email import header
 import re
 import requests
 
@@ -12,7 +11,6 @@ from flask import Blueprint, jsonify, request, make_response, current_app
 from sqlalchemy import select, distinct, or_
 from sqlalchemy.sql import func, text
 from sqlalchemy.orm import joinedload, lazyload
-from sqlalchemy.sql.expression import func
 
 from .models import (
     NcbiMetadata,
@@ -21,6 +19,7 @@ from .models import (
     Marker,
     OtuIndexed,
     CondensedProfile,
+    CondensedProfileCtas1,
     Taxonomy,
     SandpiperCache,
 )
@@ -506,36 +505,36 @@ def taxonomy_search_core(taxon, args, no_limit=False, include_extras=False):
         if include_extras:
             stmt = select(
                 NcbiMetadata.acc,
-                CondensedProfile.relative_abundance,
-                CondensedProfile.filled_coverage,
+                CondensedProfileCtas1.relative_abundance,
+                CondensedProfileCtas1.filled_coverage,
                 NcbiMetadata.taxon_name,
                 NcbiMetadata.published,
                 # TODO: Add experiment title here, not currently in DB
                 ParsedSampleAttribute.host_or_not_mature,
                 ParsedSampleAttribute.latitude, ParsedSampleAttribute.longitude,
-            ).where(CondensedProfile.run_id == NcbiMetadata.id
+            ).where(CondensedProfileCtas1.run_id == NcbiMetadata.id
             ).where(ParsedSampleAttribute.run_id == NcbiMetadata.id)
         else:
             stmt = select(
                 NcbiMetadata.acc,
-                CondensedProfile.relative_abundance,
-                CondensedProfile.filled_coverage,
+                CondensedProfileCtas1.relative_abundance,
+                CondensedProfileCtas1.filled_coverage,
                 NcbiMetadata.taxon_name,
                 NcbiMetadata.published,
                 # TODO: Add experiment title here, not currently in DB
-            ).where(CondensedProfile.run_id == NcbiMetadata.id)
+            ).where(CondensedProfileCtas1.run_id == NcbiMetadata.id)
 
         
         if sort_field == 'relative_abundance':
             if sort_direction == 'desc':
-                hits_query = stmt.order_by(CondensedProfile.relative_abundance.desc())
+                hits_query = stmt.order_by(CondensedProfileCtas1.relative_abundance.desc())
             else:
-                hits_query = stmt.order_by(CondensedProfile.relative_abundance.asc())
+                hits_query = stmt.order_by(CondensedProfileCtas1.relative_abundance.asc())
         elif sort_field == 'coverage':
             if sort_direction == 'desc':
-                hits_query = stmt.order_by(CondensedProfile.filled_coverage.desc())
+                hits_query = stmt.order_by(CondensedProfileCtas1.filled_coverage.desc())
             else:
-                hits_query = stmt.order_by(CondensedProfile.filled_coverage.asc())
+                hits_query = stmt.order_by(CondensedProfileCtas1.filled_coverage.asc())
         elif sort_field == 'release_year':
             if sort_direction == 'desc':
                 hits_query = stmt.order_by(NcbiMetadata.releasedate.desc())
@@ -545,12 +544,9 @@ def taxonomy_search_core(taxon, args, no_limit=False, include_extras=False):
         if not no_limit:
             hits_query = hits_query.limit(page_size).offset((page-1)*page_size)
             
-        from datetime import datetime
-        print('=== {}: before exe'.format(datetime.now().strftime('%Y-%m-%d %H:%M:%S')))
         condensed_profile_hits = db.session.execute(
             hits_query.where(
-                CondensedProfile.taxonomy_id == taxonomy.id))
-        print('=== {}: after exe'.format(datetime.now().strftime('%Y-%m-%d %H:%M:%S')))
+                CondensedProfileCtas1.taxonomy_id == taxonomy.id))
 
         return True, condensed_profile_hits
 

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -107,6 +107,15 @@ class CondensedProfile(db.Model):
     taxonomy = db.relationship("Taxonomy", back_populates="condensed_profiles", foreign_keys=[taxonomy_id])
 
 
+class CondensedProfileCtas1(db.Model):
+    '''Materialized subset of CondensedProfile for taxonomy search performance.'''
+    __tablename__ = 'condensed_profiles_ctas1'
+    taxonomy_id = db.Column(db.Integer, db.ForeignKey('taxonomies.id'), primary_key=True, index=True)
+    run_id = db.Column(db.Integer, db.ForeignKey('ncbi_metadata.id'), primary_key=True, index=True)
+    relative_abundance = db.Column(db.Float, nullable=False, index=True)
+    filled_coverage = db.Column(db.Float, nullable=False, index=True)
+
+
 class Taxonomy(db.Model):
     # Not used here but this is the logical place to put it since it is used in the condensed profile, plus maybe otus in the future
     # taxonomy_level_columns = ['domain_id','phylum_id','class_id','order_id','family_id','genus_id','species_id']

--- a/backend/bin/create_condensed_profiles_ctas.py
+++ b/backend/bin/create_condensed_profiles_ctas.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import argparse
+import duckdb
+
+
+def main(db_path: str):
+    con = duckdb.connect(db_path)
+    con.execute(
+        """
+        CREATE OR REPLACE TABLE condensed_profiles_ctas1 AS
+        SELECT taxonomy_id, run_id, relative_abundance, filled_coverage
+        FROM condensed_profiles
+        ORDER BY taxonomy_id, run_id
+        """
+    )
+    con.close()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Create condensed_profiles_ctas1 table for performance"
+    )
+    parser.add_argument("db_path", help="Path to DuckDB database file")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args.db_path)

--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -53,7 +53,7 @@ localrules: run_kingfisher_metadata, gather_kingfisher_metadata, gather_bioproje
 
 rule all:
     input:
-        '{test_or_prod}/{version}/backend_db/cache_table_done'.format(
+        '{test_or_prod}/{version}/backend_db/condensed_profiles_ctas_done'.format(
             test_or_prod=config['TEST_OR_PROD'],
             version=config['SANDPIPER_VERSION']),
         '{test_or_prod}/gather_bioproject_pubs/{date}/done'.format(
@@ -377,4 +377,27 @@ rule precompute_api_cache:
         'pixi run -e sandpiper ./bin/precompute_api_cache.py ' \
         '{config[SCRATCH_DIR]}/sandpiper_{config[SANDPIPER_VERSION]}.duckdb > ' \
         '$SNAKE_WORKING_DIR/{log} 2>&1 && ' \
-        'cp {config[SCRATCH_DIR]}/sandpiper_{config[SANDPIPER_VERSION]}.duckdb db/sandpiper_{config[SANDPIPER_VERSION]}.duckdb'
+        'cp {config[SCRATCH_DIR]}/sandpiper_{config[SANDPIPER_VERSION]}.duckdb {config[SCRATCH_DIR]}/sandpiper_{config[SANDPIPER_VERSION]}.duckdb.after_precompute_api_cache && ' \
+        'cp {config[SCRATCH_DIR]}/sandpiper_{config[SANDPIPER_VERSION]}.duckdb.after_precompute_api_cache db/sandpiper_{config[SANDPIPER_VERSION]}.duckdb'
+
+rule create_condensed_profiles_ctas:
+    input:
+        '{test_or_prod}/{version}/backend_db/cache_table_done'.format(
+            test_or_prod=config['TEST_OR_PROD'],
+            version=config['SANDPIPER_VERSION'])
+    output:
+        touch('{test_or_prod}/{version}/backend_db/condensed_profiles_ctas_done'.format(
+            test_or_prod=config['TEST_OR_PROD'],
+            version=config['SANDPIPER_VERSION']))
+    log:
+        '{test_or_prod}/{version}/backend_db/condensed_profiles_ctas.log'.format(
+            test_or_prod=config['TEST_OR_PROD'],
+            version=config['SANDPIPER_VERSION'])
+    shell:
+        'export SNAKE_WORKING_DIR=`pwd` && ' \
+        'cd ../backend && ' \
+        'cp {config[SCRATCH_DIR]}/sandpiper_{config[SANDPIPER_VERSION]}.duckdb.after_precompute_api_cache {config[SCRATCH_DIR]}/sandpiper_{config[SANDPIPER_VERSION]}.duckdb && ' \
+        'pixi run -e sandpiper ./bin/create_condensed_profiles_ctas.py {config[SCRATCH_DIR]}/sandpiper_{config[SANDPIPER_VERSION]}.duckdb > ' \
+        '$SNAKE_WORKING_DIR/{log} 2>&1 && ' \
+        'cp {config[SCRATCH_DIR]}/sandpiper_{config[SANDPIPER_VERSION]}.duckdb {config[SCRATCH_DIR]}/sandpiper_{config[SANDPIPER_VERSION]}.duckdb.after_condensed_profiles_ctas && ' \
+        'cp {config[SCRATCH_DIR]}/sandpiper_{config[SANDPIPER_VERSION]}.duckdb.after_condensed_profiles_ctas db/sandpiper_{config[SANDPIPER_VERSION]}.duckdb'

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -46,6 +46,20 @@ def servers():
     env = os.environ.copy()
     env["SANDPIPER_TESTING"] = "1"
 
+    # Ensure CTAS table exists for tests
+    subprocess.run(
+        [
+            "pixi",
+            "run",
+            "-e",
+            "sandpiper",
+            "./bin/create_condensed_profiles_ctas.py",
+            "db/sandpiper_21_test.duckdb",
+        ],
+        cwd="backend",
+        check=True,
+    )
+
     backend_cmd = [
         "pixi",
         "run",


### PR DESCRIPTION
## Summary
- clean up CTAS integration by removing debug prints and unused imports
- ensure tests build the CTAS table via dedicated script
- stage CTAS generation via scratch and persist precompute DB as `after_precompute_api_cache`

## Testing
- `pytest tests --capture=no -v`
- `snakemake -c 1 --config SCRATCH_DIR=~ --configfile test_config.yml` from `snakemake_test`


------
https://chatgpt.com/codex/tasks/task_e_68bb584ce708832aa18ef780bb7f1bbb