### PR TITLE
Make taxonomy search autocomplete case-insensitive

### DIFF
--- a/backend/api/api.py
+++ b/backend/api/api.py
@@ -561,8 +561,12 @@ def taxonomy_search_hints(taxon):
     taxonomy_type = request.args.get('taxonomy_type', 'gtdb')
 
     # Underscores are wildcards, but we don't want that since there are names like p__Actinobacteria
-    sql = "select name from taxonomies where taxonomy_type = :taxonomy_type and name like :taxon escape \'\\\' order by name limit 30"
-    results = db.session.execute(text(sql), {'taxon': '%'+taxon.replace('_','\\_')+'%', 'taxonomy_type': taxonomy_type})
+    search = '%'+taxon.lower().replace('_','\\_')+'%'
+    sql = (
+        "select name from taxonomies where taxonomy_type = :taxonomy_type "
+        "and lower(name) like :taxon escape \'\\' order by name limit 30"
+    )
+    results = db.session.execute(text(sql), {'taxon': search, 'taxonomy_type': taxonomy_type})
     taxonomies = []
     for r in results:
         taxonomies.append(r)

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -146,3 +146,16 @@ def test_taxonomy_search_csv_filename():
     assert resp.status_code == 200
     cd = resp.headers.get("Content-Disposition")
     assert cd is not None and taxonomy_type in cd
+
+
+def test_taxonomy_search_hints_case_insensitive():
+    session = requests.Session()
+    resp_lower = session.get(
+        f"{BACKEND_URL}/api/taxonomy_search_hints/bac?taxonomy_type=gtdb"
+    )
+    resp_mixed = session.get(
+        f"{BACKEND_URL}/api/taxonomy_search_hints/BaC?taxonomy_type=gtdb"
+    )
+    assert resp_lower.status_code == 200
+    assert resp_lower.json() == resp_mixed.json()
+    assert resp_lower.json().get("taxonomies")


### PR DESCRIPTION
## Summary
- make taxonomy search hints lookups case-insensitive
- add test for case-insensitive taxonomy search hints

## Testing
- `pixi run -e sandpiper pytest tests --capture=no -v`


------
https://chatgpt.com/codex/tasks/task_e_68bb5f48327c832ab900dc028ea530a5