### PR TITLE
Align taxonomy switch UI across search views

### DIFF
--- a/vue/src/views/Search.vue
+++ b/vue/src/views/Search.vue
@@ -13,16 +13,24 @@
           <template #empty>No results found</template>
         </b-autocomplete>
       </b-field>
-      <b-field>
-        <b-radio v-model="taxonomy_db" native-value="gtdb">
-          <a href='http://gtdb.ecogenomic.org'>Genome Taxonomy Database (GTDB)</a> version {{ gtdb_version }} taxonomy
-        </b-radio>
-      </b-field>
-      <b-field>
-        <b-radio v-model="taxonomy_db" native-value="globdb">
-          <a href='http://globdb.org'>GlobDB</a> version {{ gtdb_version }} taxonomy
-        </b-radio>
-      </b-field>
+      <div class="taxonomy-switcher">
+        <b-field>
+          <b-radio-button v-model="taxonomy_db" native-value="gtdb">
+            GTDB
+          </b-radio-button>
+          <b-radio-button v-model="taxonomy_db" native-value="globdb">
+            GlobDB
+          </b-radio-button>
+        </b-field>
+        <p class="help">
+          <span v-if="taxonomy_db === 'gtdb'">
+            <a href='http://gtdb.ecogenomic.org'>Genome Taxonomy Database (GTDB)</a> version {{ gtdb_version }} taxonomy
+          </span>
+          <span v-else>
+            <a href='http://globdb.org'>GlobDB</a> version {{ gtdb_version }} taxonomy
+          </span>
+        </p>
+      </div>
       <br /><b-button type="is-primary" @click="search_by_taxonomy">Search</b-button>
     </section>
 

--- a/vue/src/views/SearchResult.vue
+++ b/vue/src/views/SearchResult.vue
@@ -11,16 +11,29 @@
           </h1>
         <p style="text-align: center;">{{ lineage.join('; ') }}</p>
         <br />
-        <p style="text-align: center;">
-          Viewing {{ taxonomy_type === 'gtdb' ? 'GTDB' : 'GlobDB' }} entry.
-          <span v-if="other_taxon_available">           
-             <router-link :to="{ name: 'SearchResults', params: { taxonomy }, query: { taxonomy_type: other_taxonomy_type } }">
-              Switch to {{ other_taxonomy_type === 'gtdb' ? 'GTDB' : 'GlobDB' }}.
-            </router-link>
-          </span>
-          <span v-else-if="taxonomy_type==='gtdb'">Taxon not available in GlobDB view.</span>
-          <span v-else>Taxon not available in GTDB view.</span>
-        </p>
+        <div class="has-text-centered taxonomy-switcher">
+          <b-field grouped position="is-centered">
+            <b-radio-button
+              v-model="taxonomy_type"
+              native-value="gtdb"
+              :disabled="disableGtdb"
+              @input="onTaxonomyTypeChange">
+              GTDB
+            </b-radio-button>
+            <b-radio-button
+              v-model="taxonomy_type"
+              native-value="globdb"
+              :disabled="disableGlobdb"
+              @input="onTaxonomyTypeChange">
+              GlobDB
+            </b-radio-button>
+          </b-field>
+          <p class="help">Viewing {{ taxonomy_type === 'gtdb' ? 'GTDB' : 'GlobDB' }} entry.</p>
+          <p class="help" v-if="other_taxon_available === false">
+            <span v-if="taxonomy_type==='gtdb'">Taxon not available in GlobDB view.</span>
+            <span v-else>Taxon not available in GTDB view.</span>
+          </p>
+        </div>
       </section>
 
       <section class="section">
@@ -226,6 +239,14 @@ export default {
       zoom: default_zoom
     }
   },
+  computed: {
+    disableGtdb () {
+      return this.taxonomy_type === 'globdb' && this.other_taxon_available === false
+    },
+    disableGlobdb () {
+      return this.taxonomy_type === 'gtdb' && this.other_taxon_available === false
+    }
+  },
   created () {
     // fetch the data when the view is created and the data is
     // already being observed
@@ -238,6 +259,7 @@ export default {
     fetchGlobalData () {
       this.taxonomy_type = this.$route.query.taxonomy_type || 'gtdb'
       this.other_taxonomy_type = this.taxonomy_type === 'gtdb' ? 'globdb' : 'gtdb'
+      this.other_taxon_available = null
       fetchGlobalDataByTaxonomy(this.taxonomy, this.taxonomy_type)
         .then(response => {
           if (response.data.total_num_results > 0) {
@@ -270,6 +292,17 @@ export default {
         .then(response => {
           this.search_result = response.data.results
         })
+    },
+    onTaxonomyTypeChange (value) {
+      if (value === this.$route.query.taxonomy_type) {
+        return
+      }
+
+      this.$router.push({
+        name: 'SearchResults',
+        params: { taxonomy: this.taxonomy },
+        query: { taxonomy_type: value }
+      })
     },
     onPageChange (page) {
       this.page = page


### PR DESCRIPTION
## Summary
- replace the taxonomy radio buttons on the Search page with the GTDB/GlobDB switch used on the run view
- apply the same switch on the Search Results page, including disabling unavailable taxonomy options and routing updates on toggle

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912c6d9c6a8832abe3c849edfcfd3da)