### PR TITLE
Cache run sunburst data per taxonomy selection

### DIFF
--- a/vue/src/views/Run.vue
+++ b/vue/src/views/Run.vue
@@ -171,6 +171,7 @@ export default {
   data: function () {
     return {
       condensed_tree: null,
+      condensed_cache: {},
       metadata: null,
       error_message: null,
       taxonomy_db: 'gtdb'
@@ -254,14 +255,25 @@ export default {
   methods: {
     fetchCondensed () {
       const accession = this.accession
-      fetchRunCondensed(accession, this.taxonomy_db)
+      const taxonomy = this.taxonomy_db
+
+      if (this.condensed_cache[taxonomy] !== undefined) {
+        this.condensed_tree = this.condensed_cache[taxonomy]
+        return
+      }
+
+      fetchRunCondensed(accession, taxonomy)
         .then(response => {
           this.condensed_tree = response.data
+          this.condensed_cache[taxonomy] = response.data
         })
     },
     fetchData () {
       // const accession = this.$route.params.accession
       const accession = this.accession
+
+      this.condensed_cache = {}
+      this.condensed_tree = null
 
       this.fetchCondensed()
 


### PR DESCRIPTION
## Summary
- cache run taxonomy sunburst responses keyed by selected database
- reset cached data when the run accession changes to avoid stale content

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912d5a830bc832a871a6d87a53c2e37)