### PR TITLE
Enable cross-taxonomy taxonomy search suggestions

### DIFF
--- a/backend/api/api.py
+++ b/backend/api/api.py
@@ -584,15 +584,23 @@ def taxonomy_search_core(taxon, args, no_limit=False, include_extras=False):
 @api.route('/taxonomy_search_hints/<string:taxon>', methods=('GET',))
 def taxonomy_search_hints(taxon):
     if len(taxon) < 3: return jsonify(['3 or more characters are required'])
-    taxonomy_type = request.args.get('taxonomy_type', 'gtdb')
+    taxonomy_type = request.args.get('taxonomy_type', None)
 
     # Underscores are wildcards, but we don't want that since there are names like p__Actinobacteria
     search = '%'+taxon.lower().replace('_','\\_')+'%'
-    sql = (
-        "select name from taxonomies where taxonomy_type = :taxonomy_type "
-        "and lower(name) like :taxon escape \'\\' order by name limit 30"
-    )
-    results = db.session.execute(text(sql), {'taxon': search, 'taxonomy_type': taxonomy_type})
+    if taxonomy_type is None:
+        sql = (
+            "select name from taxonomies "
+            "where lower(name) like :taxon escape \'\\' "
+            "order by taxonomy_type, name limit 30"
+        )
+        results = db.session.execute(text(sql), {'taxon': search})
+    else:
+        sql = (
+            "select name from taxonomies where taxonomy_type = :taxonomy_type "
+            "and lower(name) like :taxon escape \'\\' order by name limit 30"
+        )
+        results = db.session.execute(text(sql), {'taxon': search, 'taxonomy_type': taxonomy_type})
     taxonomies = []
     for r in results:
         taxonomies.append(r)

--- a/vue/src/api/index.ts
+++ b/vue/src/api/index.ts
@@ -46,8 +46,9 @@ export function fetchGlobalDataByTaxonomy (taxonomy: string, taxonomyType: strin
   return axios.get(`${API_URL}/taxonomy_search_global_data/${taxonomy}?taxonomy_type=${taxonomyType}`)
 }
 
-export function fetchTaxonomySearchHints (taxonomy: string, taxonomyType: string) {
-  return axios.get(`${API_URL}/taxonomy_search_hints/${taxonomy}?taxonomy_type=${taxonomyType}`)
+export function fetchTaxonomySearchHints (taxonomy: string, taxonomyType?: string) {
+  const taxonomyTypeParam = taxonomyType ? `?taxonomy_type=${taxonomyType}` : ''
+  return axios.get(`${API_URL}/taxonomy_search_hints/${taxonomy}${taxonomyTypeParam}`)
 }
 
 export function fetchRandomAccession(host: boolean, ecological: boolean, two_gbp: boolean) {

--- a/vue/src/views/Run.vue
+++ b/vue/src/views/Run.vue
@@ -79,10 +79,10 @@
         <div class="container">
           <h3 class="title">Taxonomic profile</h3>
           <b-field>
-            <b-radio-button v-model="taxonomy_db" native-value="gtdb" @input="fetchCondensed" type="is-info">
+            <b-radio-button v-model="taxonomy_db" native-value="gtdb" @input="fetchCondensed" type="is-warning">
               GTDB
             </b-radio-button>
-            <b-radio-button v-model="taxonomy_db" native-value="globdb" @input="fetchCondensed" type="is-info">
+            <b-radio-button v-model="taxonomy_db" native-value="globdb" @input="fetchCondensed" type="is-warning">
               GlobDB
             </b-radio-button>
           </b-field>

--- a/vue/src/views/Search.vue
+++ b/vue/src/views/Search.vue
@@ -13,24 +13,11 @@
           <template #empty>No results found</template>
         </b-autocomplete>
       </b-field>
-      <div class="taxonomy-switcher">
-        <b-field>
-          <b-radio-button v-model="taxonomy_db" native-value="gtdb" type="is-info">
-            GTDB
-          </b-radio-button>
-          <b-radio-button v-model="taxonomy_db" native-value="globdb" type="is-info">
-            GlobDB
-          </b-radio-button>
-        </b-field>
-        <p class="help">
-          <span v-if="taxonomy_db === 'gtdb'">
-            Searching for <a href='http://gtdb.ecogenomic.org'>Genome Taxonomy Database (GTDB)</a> version {{ gtdb_version }} taxonomy
-          </span>
-          <span v-else>
-            Searching for <a href='http://globdb.org'>GlobDB</a> version {{ gtdb_version }} taxonomy
-          </span>
-        </p>
-      </div>
+      <p class="help">
+        Suggestions include <a href='http://gtdb.ecogenomic.org'>Genome Taxonomy Database (GTDB)</a>
+        <span v-if="gtdb_version">version {{ gtdb_version }}</span>
+        and <a href='http://globdb.org'>GlobDB</a> taxonomies.
+      </p>
       <br /><b-button type="is-primary" @click="search_by_taxonomy">Search</b-button>
     </section>
 
@@ -66,7 +53,6 @@ export default {
   data () {
     return {
       gtdb_version: null,
-      taxonomy_db: 'gtdb',
 
       taxonomy: 'c__Bog-38',
       autocomplete_taxons: [],
@@ -109,7 +95,7 @@ export default {
         })
     },
     search_by_taxonomy () {
-      this.$router.push({ name: 'SearchResults', params: { taxonomy: this.taxonomy }, query: { taxonomy_type: this.taxonomy_db } })
+      this.$router.push({ name: 'SearchResults', params: { taxonomy: this.taxonomy } })
     },
     getAsyncData: debounce(function (name) {
       // if undefined or empty, reset the list
@@ -118,7 +104,7 @@ export default {
         return
       }
       this.isFetching = true
-      fetchTaxonomySearchHints(name, this.taxonomy_db)
+      fetchTaxonomySearchHints(name)
         .then(({ data }) => {
           this.autocomplete_taxons = data.taxonomies
           if (this.autocomplete_taxons != undefined && this.autocomplete_taxons.length >= 30) {

--- a/vue/src/views/SearchResult.vue
+++ b/vue/src/views/SearchResult.vue
@@ -16,14 +16,14 @@
             <b-radio-button
               v-model="taxonomy_type"
               native-value="gtdb"
-              :disabled="disableGtdb" type="is-info"
+              :disabled="disableGtdb" type="is-warning"
               @input="onTaxonomyTypeChange('gtdb')">
               GTDB
             </b-radio-button>
             <b-radio-button
               v-model="taxonomy_type"
               native-value="globdb"
-              :disabled="disableGlobdb" type="is-info"
+              :disabled="disableGlobdb" type="is-warning"
               @input="onTaxonomyTypeChange('globdb')">
               GlobDB
             </b-radio-button>
@@ -256,36 +256,90 @@ export default {
     reset_map: function () {
       this.zoom = default_zoom
     },
-    fetchGlobalData () {
-      this.taxonomy_type = this.$route.query.taxonomy_type || 'gtdb'
-      this.other_taxonomy_type = this.taxonomy_type === 'gtdb' ? 'globdb' : 'gtdb'
+    async fetchGlobalData () {
       this.other_taxon_available = null
-      fetchGlobalDataByTaxonomy(this.taxonomy, this.taxonomy_type)
-        .then(response => {
-          if (response.data.total_num_results > 0) {
-            this.taxon_name = response.data.taxon_name
-            this.lineage = response.data.lineage
-            this.taxonomy_level = response.data.taxonomy_level
-            this.total_num_results = response.data.total_num_results
-            this.lat_lons = response.data.lat_lons
-            this.lat_lons_min_relabund = response.data.lat_lons_min_relabund
-            this.num_lat_lon_runs = response.data.num_lat_lon_runs
-            this.num_host_runs = response.data.num_host_runs
-            this.num_ecological_runs = response.data.num_ecological_runs
-          } else {
-            this.error_message = response.data.taxon
-          }
-        })
+      this.error_message = null
+      this.search_result = null
+      this.total_num_results = null
 
-      fetchGlobalDataByTaxonomy(this.taxonomy, this.other_taxonomy_type)
-        .then(response => {
-          this.other_taxon_available = response.data.total_num_results > 0
-        })
-        .catch(() => { this.other_taxon_available = false })
+      const requestedTaxonomyType = this.$route.query.taxonomy_type
 
-      this.fetchData() // call here so that this and the run data are loaded by the watch in a single function
+      if (requestedTaxonomyType) {
+        const globalDataResult = await this.fetchGlobalDataForType(requestedTaxonomyType)
+        if (!globalDataResult.success) {
+          this.error_message = globalDataResult.error
+          return
+        }
+        this.taxonomy_type = requestedTaxonomyType
+        this.populateGlobalData(globalDataResult.data)
+      } else {
+        const detected = await this.determineInitialTaxonomyType()
+        if (!detected) {
+          return
+        }
+      }
+
+      this.other_taxonomy_type = this.taxonomy_type === 'gtdb' ? 'globdb' : 'gtdb'
+      this.fetchData()
+      this.checkOtherTaxonomyAvailability()
+    },
+    async fetchGlobalDataForType (taxonomyType) {
+      try {
+        const response = await fetchGlobalDataByTaxonomy(this.taxonomy, taxonomyType)
+        if (typeof response.data.total_num_results === 'number' && response.data.total_num_results > 0) {
+          return { success: true, data: response.data }
+        }
+        const errorMessage = response.data && response.data.taxon ? response.data.taxon : 'No results found.'
+        return { success: false, error: errorMessage }
+      } catch (error) {
+        return { success: false, error: error.message }
+      }
+    },
+    populateGlobalData (data) {
+      this.taxon_name = data.taxon_name
+      this.lineage = data.lineage
+      this.taxonomy_level = data.taxonomy_level
+      this.total_num_results = data.total_num_results
+      this.lat_lons = data.lat_lons
+      this.lat_lons_min_relabund = data.lat_lons_min_relabund
+      this.num_lat_lon_runs = data.num_lat_lon_runs
+      this.num_host_runs = data.num_host_runs
+      this.num_ecological_runs = data.num_ecological_runs
+    },
+    async determineInitialTaxonomyType () {
+      const gtdbResult = await this.fetchGlobalDataForType('gtdb')
+      if (gtdbResult.success) {
+        this.taxonomy_type = 'gtdb'
+        this.populateGlobalData(gtdbResult.data)
+        return true
+      }
+
+      const globdbResult = await this.fetchGlobalDataForType('globdb')
+      if (globdbResult.success) {
+        this.taxonomy_type = 'globdb'
+        this.populateGlobalData(globdbResult.data)
+        return true
+      }
+
+      this.error_message = globdbResult.error || gtdbResult.error || 'No results found.'
+      return false
+    },
+    async checkOtherTaxonomyAvailability () {
+      if (!this.other_taxonomy_type) {
+        this.other_taxon_available = null
+        return
+      }
+      try {
+        const response = await fetchGlobalDataByTaxonomy(this.taxonomy, this.other_taxonomy_type)
+        this.other_taxon_available = typeof response.data.total_num_results === 'number' && response.data.total_num_results > 0
+      } catch (error) {
+        this.other_taxon_available = false
+      }
     },
     fetchData () {
+      if (!this.taxonomy_type) {
+        return
+      }
       this.search_result = null
 
       fetchRunsByTaxonomy(this.taxonomy, this.taxonomy_type, this.page, this.sortField, this.sortDirection, this.pageSize)


### PR DESCRIPTION
## Summary
- expand taxonomy search hints to query across all taxonomy databases and remove the selector from the search page
- update search results to auto-detect the preferred taxonomy (defaulting to GTDB) and restyle taxonomy switches
- restyle run taxonomy toggles to match the new warning emphasis

## Testing
- pytest tests --capture=no -v *(fails: Catalog Error: Table with name condensed_profiles_ctas1 does not exist)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912e8461504832aa4a491f7971402e7)