### PR TITLE
Add Snakemake metadata download workflow

### DIFF
--- a/snakemake_metadata/Snakefile
+++ b/snakemake_metadata/Snakefile
@@ -1,0 +1,11 @@
+# Snakemake workflow for metadata downloads
+
+rule all:
+    input:
+        "2024-08/sylph.tsv.gz"
+
+rule download_allthebacteria_sylph:
+    output:
+        "2024-08/sylph.tsv.gz"
+    shell:
+        "mkdir -p $(dirname {output}) && curl -L -o {output} https://osf.io/download/nu5a6/"


### PR DESCRIPTION
## Summary
- add a Snakemake workflow under `snakemake_metadata` to download Sylph metadata
- include default target for `2024-08/sylph.tsv.gz`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d3ddf51fc832a86af005dc7005d57)