### PR TITLE
Add DuckDB resource limits

### DIFF
--- a/backend/api/application.py
+++ b/backend/api/application.py
@@ -36,6 +36,10 @@ def create_app(app_name='SURVEY_API'):
 
     from api.models import db
     db.init_app(app)
+    from api.duckdb_limits import register_duckdb_limits
+
+    with app.app_context():
+        register_duckdb_limits(db.engine)
 
     return app
 

--- a/backend/api/duckdb_limits.py
+++ b/backend/api/duckdb_limits.py
@@ -1,0 +1,24 @@
+"""Utilities to apply DuckDB resource limits consistently."""
+
+from sqlalchemy import event
+
+
+def configure_duckdb_connection(connection):
+    """Apply resource limits to a DuckDB connection."""
+
+    connection.execute("SET memory_limit='1GB'")
+    connection.execute("SET threads=2")
+    connection.execute("SET temp_directory='/tmp/duckdb_spill'")
+
+
+def register_duckdb_limits(engine):
+    """Ensure DuckDB limits are applied for all SQLAlchemy connections."""
+
+    if getattr(engine, "_duckdb_limits_registered", False):
+        return
+
+    @event.listens_for(engine, "connect")
+    def _set_duckdb_limits(dbapi_connection, connection_record):  # pragma: no cover - SQLAlchemy hook
+        configure_duckdb_connection(dbapi_connection)
+
+    engine._duckdb_limits_registered = True

--- a/backend/bin/create_condensed_profiles_ctas.py
+++ b/backend/bin/create_condensed_profiles_ctas.py
@@ -1,10 +1,17 @@
 #!/usr/bin/env python3
 import argparse
 import duckdb
+import os
+import sys
+
+sys.path = [os.path.join(os.path.dirname(os.path.realpath(__file__)), ".."), *sys.path]
+
+from api.duckdb_limits import configure_duckdb_connection
 
 
 def main(db_path: str):
     con = duckdb.connect(db_path)
+    configure_duckdb_connection(con)
     con.execute(
         """
         CREATE OR REPLACE TABLE condensed_profiles_ctas1 AS

--- a/backend/bin/generate_backend_db
+++ b/backend/bin/generate_backend_db
@@ -45,6 +45,7 @@ import duckdb
 
 sys.path = [os.path.join(os.path.dirname(os.path.realpath(__file__)), '..')] + sys.path
 from api.application import generate_app
+from api.duckdb_limits import configure_duckdb_connection, register_duckdb_limits
 
 # from flask import Flask
 from sqlalchemy import update, bindparam, select, insert, func
@@ -1250,6 +1251,7 @@ if __name__ == '__main__':
     app.config['SQLALCHEMY_ECHO'] = args.debug is True
     db.init_app(app)
     with app.app_context():
+        register_duckdb_limits(db.engine)
         if args.stage == 'start' or args.stage == 'stage2':
             blacklist = set()
             if args.run_blacklist:
@@ -1279,6 +1281,7 @@ if __name__ == '__main__':
                 os.remove(db_path)
             logging.info("Making new DB ..")
             conn = duckdb.connect(db_path)
+            configure_duckdb_connection(conn)
             # Create sequences for autoincrementing IDs
             seqs = [
                 'otus_id_seq',

--- a/backend/bin/precompute_api_cache.py
+++ b/backend/bin/precompute_api_cache.py
@@ -17,6 +17,7 @@ from api.models import (
 )
 from sqlalchemy.sql import func
 from sqlalchemy import distinct
+from api.duckdb_limits import register_duckdb_limits
 
 from sandpiper.biosample_attributes import BioSampleAttributes, NcbiMetadataExtraInfos
 
@@ -26,6 +27,7 @@ def main(db_path: str):
     app.config["SQLALCHEMY_DATABASE_URI"] = f"duckdb:///{db_path}"
     db.init_app(app)
     with app.app_context():
+        register_duckdb_limits(db.engine)
         db.create_all()
         SandpiperCache.query.delete()
 


### PR DESCRIPTION
## Summary
- add centralized DuckDB configuration to enforce memory, thread, and spill directory limits
- apply the limits to Flask app connections and DuckDB utility scripts

## Testing
- pytest tests --capture=no -v

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fd43ae888832a8f9845bdfc23337c)