### PR TITLE
Set autocommit isolation for read-only DuckDB

### DIFF
--- a/backend/api/config.py
+++ b/backend/api/config.py
@@ -12,10 +12,12 @@ class BaseConfig:
     if os.environ.get('SANDPIPER_TESTING'):
         print("Running in DB testing mode")
         DB_NAME = 'sandpiper_21_test.duckdb'
+        db_connect_args = {}
     else:
         print("Running in DB production mode")
         # Open read-only to avoid database lock issues.
         DB_NAME = 'sandpiper_35.duckdb?access_mode=READ_ONLY'
+        db_connect_args = {"read_only": True}
     LYRA_DB_PATH = 'duckdb:///'+os.path.join(os.path.dirname(__file__), '../db/{}'.format(DB_NAME))
     # LYRA_DB_PATH = 'duckdb:////scratch/sandpiper/sandpiper_33.duckdb'
     # LYRA_DB_PATH = 'duckdb:////scratch/sandpiper/sandpiper_19_test.duckdb'
@@ -30,9 +32,11 @@ class BaseConfig:
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_ECHO=True
-    # Avoid explicit ROLLBACK statements when using DuckDB in read-only mode so
-    # graceful shutdowns are not delayed by unnecessary transaction cleanup.
     SQLALCHEMY_ENGINE_OPTIONS = {
-        "isolation_level": "AUTOCOMMIT",
-        "connect_args": {"read_only": True},
+        # Avoid explicit ROLLBACK statements when using DuckDB in read-only mode so
+        # graceful shutdowns are not delayed by unnecessary transaction cleanup.
+        # During testing we leave the isolation level unset so SQLAlchemy uses
+        # DuckDB's defaults, which keeps the test database writable.
+        "connect_args": db_connect_args,
+        **({"isolation_level": "AUTOCOMMIT"} if db_connect_args else {}),
     }


### PR DESCRIPTION
## Summary
- configure SQLAlchemy to use AUTOCOMMIT isolation when connecting to DuckDB
- document intent to avoid rollback noise during graceful shutdowns in read-only mode

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930c588612c832a998aed817abef29d)