### PR TITLE
Remove taxonomy cache dependency for full profile lookup

### DIFF
--- a/backend/api/api.py
+++ b/backend/api/api.py
@@ -301,8 +301,6 @@ def wordnode_json(wordnode, order, depth):
 
 @api.route('/full_profile/<string:sample_name>', methods=('GET',))
 def fetch_full_profile(sample_name):
-    global sandpiper_taxonomy_id_to_full_name, sandpiper_marker_id_to_name
-
     # Doesn't usually cache anything, but useful to have here for testing
     generate_cache()
 
@@ -310,14 +308,25 @@ def fetch_full_profile(sample_name):
     if run_id is None:
         return jsonify({ 'error': 'no run found for acc '+sample_name })
 
-    otus = OtuIndexed.query.filter_by(run_id=run_id, marker_id=1).order_by(OtuIndexed.id).all()
+    otus = db.session.execute(
+        select(OtuIndexed, Taxonomy.full_name)
+        .outerjoin(Taxonomy, OtuIndexed.taxonomy_id == Taxonomy.id)
+        .where(OtuIndexed.run_id == run_id)
+        .where(OtuIndexed.marker_id == 1)
+        .order_by(OtuIndexed.id)
+    ).all()
 
     root = WordNode(None, 'Root')
     taxons_to_wordnode = {root.word: root}
 
-    for (i, otu) in enumerate(otus):
-        taxonomy = ('Root' if otu.taxonomy_id==0 else 'Root; ' + sandpiper_taxonomy_id_to_full_name[otu.taxonomy_id]) if otu.taxonomy_id in sandpiper_taxonomy_id_to_full_name else otu.taxonomy_id
-        taxons = taxonomy.split('; ')+['OTU '+str(i+1)]
+    for (i, (otu, taxonomy_full_name)) in enumerate(otus):
+        if otu.taxonomy_id == 0:
+            taxonomy = 'Root'
+        elif taxonomy_full_name is not None:
+            taxonomy = 'Root; ' + taxonomy_full_name
+        else:
+            taxonomy = otu.taxonomy_id
+        taxons = taxonomy.split('; ') + ['OTU ' + str(i + 1)]
 
         last_taxon = root
         wn = None

--- a/backend/bin/precompute_api_cache.py
+++ b/backend/bin/precompute_api_cache.py
@@ -12,7 +12,6 @@ from api.models import (
     db,
     NcbiMetadata,
     Marker,
-    Taxonomy,
     SandpiperCache,
 )
 from sqlalchemy.sql import func
@@ -34,18 +33,11 @@ def main(db_path: str):
             'sandpiper_num_runs': db.session.query(func.count(distinct(NcbiMetadata.acc))).scalar(),
             'sandpiper_num_bioprojects': db.session.query(func.count(distinct(NcbiMetadata.bioproject))).scalar(),
         }
-        tax_map = {t.id: t.full_name for t in Taxonomy.query.all()}
         marker_map = {m.id: m.marker for m in Marker.query.all()}
         biosample_attrs = BioSampleAttributes(app.logger).attributes
         ncbi_infos = NcbiMetadataExtraInfos().extra_info
 
         db.session.add(SandpiperCache(key='stats', value=json.dumps(stats)))
-        db.session.add(
-            SandpiperCache(
-                key='taxonomy_id_to_full_name',
-                value=json.dumps(tax_map),
-            )
-        )
         db.session.add(
             SandpiperCache(
                 key='marker_id_to_name', value=json.dumps(marker_map)


### PR DESCRIPTION
## Summary
- stop precomputing the taxonomy_id_to_full_name cache entry when generating the database
- load taxonomy names for full profile requests via a Taxonomy join instead of relying on cached mappings

## Testing
- pytest tests --capture=no -v

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69322061a80c832aaff022f0dd600df7)